### PR TITLE
Update Common.php

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -253,8 +253,8 @@ if ( ! function_exists('get_config'))
 				}
 			}
 		}
-
-		return $_config[0] =& $config;
+		$_config[0] =& $config; 
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
Fix for `Notice: Only variable references should be returned by reference` in `Line 257` of `System/Core/Common.php`...

The issue arises in newer versions of PHP because In PHP assignment expressions always return the assigned value. So $_config[0] =& $config returns $config - but not the variable itself, but a copy of its value. And returning a reference to a temporary value wouldn't be particularly useful (changing it wouldn't do anything)

This fix has been merged in CI 2.2.1 `https://github.com/bcit-ci/CodeIgniter/commit/69b02d0f0bc46e914bed1604cfbd9bf74‌​286b2e3` (January 2015)
